### PR TITLE
Updates dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/scottbrady/dustjs-loader",
   "dependencies": {
-    "bluebird": "~2.7.1",
-    "dustjs-linkedin": "~2.5.1"
+    "bluebird": "^2.9.24",
+    "dustjs-linkedin": "^2.7.0"
   }
 }


### PR DESCRIPTION
When you browserify with `dustjs-browserify` you get templates compiled with `dustjs-linkedin@2.5.1` but if you `npm install dustjs-linkedin` you get version 2.7.0 and those are not compatible causing a `partialContext.clone` error.
